### PR TITLE
[feat] add optional README toggle and prepend kata/solution links in language-aware comments

### DIFF
--- a/scripts/background.js
+++ b/scripts/background.js
@@ -178,8 +178,9 @@ chrome.runtime.onMessage.addListener(async (request, sender, sendResponse) => {
       description,
       rank,
     } = request.codewarsData;
+    const { folderStructure = "level-problem-language" } = await chrome.storage.local.get("folderStructure");
     const fileExtension = supportedFileExtensions[languageOfUserSolution];
-    const fileName = directoryName + fileExtension;
+    const fileName = folderStructure === "language-problem" ? `mysolution${fileExtension}` : directoryName + fileExtension;
     const encodedSolution = btoa(unescape(encodeURIComponent(userSolution)));
     const encodedReadMe = btoa(unescape(encodeURIComponent(description)));
     await addReadme(

--- a/scripts/background.js
+++ b/scripts/background.js
@@ -14,6 +14,86 @@ import {
   extractRepoNameAndDirectoryName,
 } from "./helperFunctions.js";
 
+const languageCommentDelimiters = {
+  agda: { line: "--" },
+  bf: { line: null },
+  c: { line: "//" },
+  cfml: { blockStart: "<!---", blockEnd: "--->" },
+  cpp: { line: "//" },
+  cobol: { line: "*" },
+  coffeescript: { line: "#" },
+  clojure: { line: ";;" },
+  commonlisp: { line: ";;" },
+  coq: { blockStart: "(*", blockEnd: "*)" },
+  crystal: { line: "#" },
+  "c#": { line: "//" },
+  d: { line: "//" },
+  dart: { line: "//" },
+  elixir: { line: "#" },
+  elm: { line: "--" },
+  erlang: { line: "%" },
+  factor: { line: "!" },
+  forth: { line: "\\" },
+  fortran: { line: "!" },
+  fsharp: { line: "//" },
+  go: { line: "//" },
+  groovy: { line: "//" },
+  haskell: { line: "--" },
+  haxe: { line: "//" },
+  idris: { line: "--" },
+  java: { line: "//" },
+  javascript: { line: "//" },
+  julia: { line: "#" },
+  kotlin: { line: "//" },
+  lambdacalc: { line: null },
+  lean: { line: "--" },
+  lua: { line: "--" },
+  nasm: { line: ";" },
+  nim: { line: "#" },
+  objc: { line: "//" },
+  ocaml: { blockStart: "(*", blockEnd: "*)" },
+  pascal: { blockStart: "{", blockEnd: "}" },
+  perl: { line: "#" },
+  php: { line: "//" },
+  powershell: { line: "#" },
+  prolog: { line: "%" },
+  purescript: { line: "--" },
+  python: { line: "#" },
+  r: { line: "#" },
+  reason: { blockStart: "/*", blockEnd: "*/" },
+  racket: { line: ";" },
+  raku: { line: "#" },
+  riscv: { line: "#" },
+  ruby: { line: "#" },
+  rust: { line: "//" },
+  scala: { line: "//" },
+  solidity: { line: "//" },
+  shell: { line: "#" },
+  sql: { line: "--" },
+  swift: { line: "//" },
+  typescript: { line: "//" },
+  vb: { line: "'" },
+};
+
+const makeCommentHeader = (language, kataUrl, solutionUrl) => {
+  const delimiters = languageCommentDelimiters[language] || { line: "#" };
+  const lines = [`Kata: ${kataUrl}`, `My solution: ${solutionUrl}`];
+  if (delimiters.line) {
+    return `${lines.map((line) => `${delimiters.line} ${line}`).join("\n")}\n\n`;
+  }
+  if (delimiters.blockStart && delimiters.blockEnd) {
+    return `${delimiters.blockStart}\n${lines.join("\n")}\n${delimiters.blockEnd}\n\n`;
+  }
+  return "";
+};
+
+const getSolutionPath = (folderStructure, rank, language, directoryName, fileName) => {
+  if (folderStructure === "language-problem") return `${language}/${directoryName}/${fileName}`;
+  if (folderStructure === "language-level-problem") return `${language}/${rank}/${directoryName}/${fileName}`;
+  if (folderStructure === "level-language-problem") return `${rank}/${language}/${directoryName}/${fileName}`;
+  return `${rank}/${directoryName}/${fileName}`;
+};
+
 chrome.runtime.onInstalled.addListener(({ reason }) => {
   if (reason === "install") {
     chrome.tabs.create({
@@ -23,6 +103,7 @@ chrome.runtime.onInstalled.addListener(({ reason }) => {
       isUserAuthenticated: false,
       isRepoConnected: false,
       folderStructure: "level-problem-language",
+      addReadmeFile: true,
     });
   }
   chrome.runtime.setUninstallURL(
@@ -48,7 +129,7 @@ chrome.runtime.onMessage.addListener(async (request, sender, sendResponse) => {
     chrome.tabs.onUpdated.addListener(onTabUpdate);
   }
 
-  if (request.action === "connectExistingRepo") {
+    if (request.action === "connectExistingRepo") {
     const { userInput } = request;
     if (userInput.length === 0 || userInput.length > 100) {
       chrome.runtime.sendMessage({
@@ -178,21 +259,43 @@ chrome.runtime.onMessage.addListener(async (request, sender, sendResponse) => {
       description,
       rank,
     } = request.codewarsData;
-    const { folderStructure = "level-problem-language" } = await chrome.storage.local.get("folderStructure");
+    const { folderStructure = "level-problem-language", addReadmeFile = true } = await chrome.storage.local.get(["folderStructure", "addReadmeFile"]);
     const fileExtension = supportedFileExtensions[languageOfUserSolution];
-    const fileName = folderStructure === "language-problem" ? `mysolution${fileExtension}` : directoryName + fileExtension;
-    const encodedSolution = btoa(unescape(encodeURIComponent(userSolution)));
-    const encodedReadMe = btoa(unescape(encodeURIComponent(description)));
-    await addReadme(
-      githubUsername,
-      repo,
-      directory,
+    const fileName =
+      folderStructure === "language-problem"
+        ? `mysolution${fileExtension}`
+        : directoryName + fileExtension;
+    const solutionPath = getSolutionPath(
+      folderStructure,
       rank,
-      directoryName,
       languageOfUserSolution,
-      encodedReadMe,
-      accessToken
+      directoryName,
+      fileName
     );
+    const solutionUrl = `https://github.com/${githubUsername}/${repo}/blob/main/${
+      directory ? `${directory}/` : ""
+    }${solutionPath}`;
+    const commentHeader = makeCommentHeader(
+      languageOfUserSolution,
+      request.codewarsData.kataUrl,
+      solutionUrl
+    );
+    const encodedSolution = btoa(
+      unescape(encodeURIComponent(`${commentHeader}${userSolution}`))
+    );
+    const encodedReadMe = btoa(unescape(encodeURIComponent(description)));
+    if (addReadmeFile) {
+      await addReadme(
+        githubUsername,
+        repo,
+        directory,
+        rank,
+        directoryName,
+        languageOfUserSolution,
+        encodedReadMe,
+        accessToken
+      );
+    }
     await addOrUpdateSolution(
       githubUsername,
       repo,

--- a/scripts/codewars.js
+++ b/scripts/codewars.js
@@ -28,6 +28,7 @@ chrome.storage.local.get(["isRepoConnected"], (result) => {
           data["name"] = nameOfChallenge;
           data["description"] = `${descriptionHeader}${parsedDescription}`;
           data["directoryName"] = json["slug"];
+          data["kataUrl"] = url;
         } catch (e) {
           console.log("Error! Unable to get description and rank: ", e);
         }

--- a/scripts/codewarsToGithub.js
+++ b/scripts/codewarsToGithub.js
@@ -125,11 +125,14 @@ const getUrl = (
     directory ? directory + "/" : ""
   }`;
 
-  if (folderStructure === "level-problem-language") {
+  if (folderStructure === "language-problem") {
     return (
-      url + `${rank}/${directoryName}/${isReadmeFile ? "README.md" : fileName}`
+      url +
+      `${languageOfUserSolution}/${directoryName}/${
+        isReadmeFile ? "README.md" : fileName
+      }`
     );
-  } else if (folderStructure === "language-level-problem") {
+  } else if (folderStructure === "level-problem-language") {
     return (
       url +
       `${languageOfUserSolution}/${rank}/${directoryName}/${

--- a/scripts/welcome.js
+++ b/scripts/welcome.js
@@ -12,9 +12,10 @@ const settingsIcon = document.querySelector("#settings-icon");
 const settingsModal = document.querySelector("#settings-modal");
 const saveSettingsBtn = document.querySelector("#save-settings-btn");
 const closeModal = document.querySelector(".close");
+const addReadmeFileCheckbox = document.querySelector("#add-readme-file");
 
 document.addEventListener("DOMContentLoaded", () => {
-  chrome.storage.local.get("folderStructure", (result) => {
+   chrome.storage.local.get(["folderStructure", "addReadmeFile"], (result) => {
     const saved = result.folderStructure || "level-problem-language";
     const radio = document.querySelector(
       `input[name="folder-structure"][value="${saved}"]`
@@ -22,6 +23,7 @@ document.addEventListener("DOMContentLoaded", () => {
     if (radio) {
       radio.checked = true;
     }
+    addReadmeFileCheckbox.checked = result.addReadmeFile !== false;
   });
 
   const params = new URLSearchParams(window.location.search);
@@ -56,7 +58,7 @@ saveSettingsBtn.addEventListener("click", () => {
   const selected = document.querySelector(
     'input[name="folder-structure"]:checked'
   ).value;
-  chrome.storage.local.set({ folderStructure: selected }, () => {
+  chrome.storage.local.set({ folderStructure: selected, addReadmeFile: addReadmeFileCheckbox.checked }, () => {
     settingsModal.style.display = "none";
     removeOpenSettingsParam();
   });

--- a/welcome.html
+++ b/welcome.html
@@ -149,28 +149,6 @@
           <div class="folder-option">
             <input
               type="radio"
-              id="language-problem"
-              name="folder-structure"
-              value="language-problem"
-            />
-            <label for="language-problem">
-              <strong>Language → Problem → mysolution.ext</strong>
-            </label>
-          </div>
-          <div class="folder-option">
-            <input
-              type="radio"
-              id="language-problem"
-              name="folder-structure"
-              value="language-problem"
-            />
-            <label for="language-problem">
-              <strong>Language → Problem → mysolution.ext</strong>
-            </label>
-          </div>
-          <div class="folder-option">
-            <input
-              type="radio"
               id="level-problem-language"
               name="folder-structure"
               value="level-problem-language"
@@ -209,6 +187,17 @@
               <div>
                 <img src="assets/levelLanguageProblem.png" />
               </div>
+            </label>
+          </div>
+          <div class="folder-option">
+            <input
+              type="radio"
+              id="language-problem"
+              name="folder-structure"
+              value="language-problem"
+            />
+            <label for="language-problem">
+              <strong>Language → Problem → mysolution.ext</strong>
             </label>
           </div>
         </div>

--- a/welcome.html
+++ b/welcome.html
@@ -143,6 +143,17 @@
           <div class="folder-option">
             <input
               type="radio"
+              id="language-problem"
+              name="folder-structure"
+              value="language-problem"
+            />
+            <label for="language-problem">
+              <strong>Language → Problem → mysolution.ext</strong>
+            </label>
+          </div>
+          <div class="folder-option">
+            <input
+              type="radio"
               id="level-problem-language"
               name="folder-structure"
               value="level-problem-language"

--- a/welcome.html
+++ b/welcome.html
@@ -141,6 +141,23 @@
             GitHub repository:
           </p>
           <div class="folder-option">
+            <input type="checkbox" id="add-readme-file" checked />
+            <label for="add-readme-file">
+              <strong>Create README.md for each kata</strong>
+            </label>
+          </div>
+          <div class="folder-option">
+            <input
+              type="radio"
+              id="language-problem"
+              name="folder-structure"
+              value="language-problem"
+            />
+            <label for="language-problem">
+              <strong>Language → Problem → mysolution.ext</strong>
+            </label>
+          </div>
+          <div class="folder-option">
             <input
               type="radio"
               id="language-problem"


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, etc.)
  * Feature update (with minor behavior adjustment) to support a more flexible Codewars-to-GitHub sync format.


* **What is the current behavior?** (You can also link to an open issue here)
  * CodeHub creates a README.md for each kata by default and uploads only the raw solution content.
  * For users organizing their repo as language/kata-name/mysolution.ext, README creation may be unnecessary, and solution files currently do not include direct links to the kata/source context.


* **What is the new behavior (if this is a feature change)?**
  * Adds a new optional setting to enable/disable per-kata README.md creation.
  * Keeps existing folder-structure options, including support for:
    * `language/kata-name/mysolution.ext`
  * Prepends metadata comments to the uploaded solution file (using language-appropriate comment syntax) with:
    * original Codewars kata URL
    * GitHub URL to the saved solution file
    * Preserves previous behavior for users who keep README creation enabled.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
  * No breaking changes expected.
  * Existing users can continue using current settings unchanged.
  * The only visible difference is the new optional README toggle and solution header comments in uploaded files.


* **Screenshots or screen recording (if appropriate)**:
<img width="655" height="874" alt="imagen" src="https://github.com/user-attachments/assets/074ca908-180c-49c8-b779-189d1ece6f9a" />
<img width="620" height="852" alt="imagen" src="https://github.com/user-attachments/assets/d8ac0ee7-d16d-4c7c-a5a8-7f5ab23acaac" />

---

# IMPORTANT
I need you @febinbellamy provide me the image for the new structure, or at least the tool that you used to create it
lmk anything, thx